### PR TITLE
SERVER-5368 log requests which took longer than 1 second

### DIFF
--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -578,9 +578,9 @@ AWS.EventListeners = {
         }
       }
 
+      var time = resp.request.service.getSkewCorrectedDate().getTime();
+      var delta = (time - req.startTime.getTime()) / 1000;
       function buildMessage() {
-        var time = resp.request.service.getSkewCorrectedDate().getTime();
-        var delta = (time - req.startTime.getTime()) / 1000;
         var ansi = logger.isTTY ? true : false;
         var status = resp.httpResponse.statusCode;
         var censoredParams = req.params;
@@ -609,6 +609,8 @@ AWS.EventListeners = {
         loggingObj.request = line;
         if (resp.error) {
             loggingObj.error = resp.error;
+        } else if (delta > 1) {
+            loggingObj.error = "Request took longer than 1s";
         }
         logger.log(loggingObj);
       } else if (typeof logger.write === 'function') {


### PR DESCRIPTION
SERVER-5368 log requests which took longer than 1 second

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
